### PR TITLE
fix bower.json and component.json version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "leaflet-omnivore",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "a geospatial format parser for Leaflet"
 }

--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-omnivore",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "a geospatial format parser for Leaflet",
   "scripts": [
     "leaflet-omnivore.js"


### PR DESCRIPTION
mapbox/leaflet-omnivore@724ede9b is missing this change.
Bower complains when installing that tag 0.2.0 is pretending to be 0.1.2.

I don't think you will be able to publish a new 0.2.0 tag without npm complaining. Maybe a 0.2.1 ?

You may use the [webpro/release-it](https://github.com/webpro/release-it) to assist you when creating a release. Doing it manually is a pain, and the `release-it` utility work quite well.
