### PR TITLE
Fix bower warning about version #

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "leaflet-omnivore",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "a geospatial format parser for Leaflet"
 }


### PR DESCRIPTION
Fixes the following bower warning:

`bower leaflet-omnivore#*      mismatch Version declared in the json (0.2.0) is different than the resolved one (0.3.0)`
