### PR TITLE
change sig of topojsonParse to match other parse methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function topojsonLoad(url, options, customLayer) {
     xhr(url, onload);
     function onload(err, response) {
         if (err) return layer.fire('error', { error: err });
-        addData(layer, topojsonParse(response.responseText));
+        topojsonParse(response.responseText, options, layer);
         layer.fire('ready');
     }
     return layer;
@@ -180,16 +180,16 @@ function polylineLoad(url, options, customLayer) {
     return layer;
 }
 
-function topojsonParse(data) {
+function topojsonParse(data, options, layer) {
     var o = typeof data === 'string' ?
         JSON.parse(data) : data;
-    var features = [];
+    layer = layer || L.geoJson();
     for (var i in o.objects) {
         var ft = topojson.feature(o, o.objects[i]);
-        if (ft.features) features = features.concat(ft.features);
-        else features = features.concat([ft]);
+        if (ft.features) addData(layer, ft.features);
+        else addData(layer, ft);
     }
-    return features;
+    return layer;
 }
 
 function csvParse(csv, options, layer) {

--- a/test/test.js
+++ b/test/test.js
@@ -175,6 +175,12 @@ test('topojson', function (t) {
     });
 });
 
+test('topojson.parse', function (t) {
+    t.plan(1);
+    var lyr = omnivore.topojson.parse(fs.readFileSync('./test/a.topojson'));
+    t.ok(lyr instanceof L.GeoJSON, 'produces geojson layer');
+});
+
 test('geojson', function (t) {
     t.plan(2);
     var layer = omnivore.geojson('a.geojson');


### PR DESCRIPTION
Modified `topojsonParse` to take the same 3 arguments as other `*Parse` methods and return an `L.GeoJSON` layer.
