### PR TITLE
Update togeojson to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/mapbox/leaflet-omnivore",
   "dependencies": {
     "csv2geojson": "~3.6.1",
-    "togeojson": "0.10.1",
+    "togeojson": "0.11.1",
     "corslite": "0.0.6",
     "wellknown": "0.3.0",
     "hintify": "~0.1.0",


### PR DESCRIPTION
This PR updates `togeojson` to version `0.11.1` (from `0.10.1`). The primary new feature is heartrate support for `.gpx` files - heartrate will be parsed into `feature.properties.heartRates`

Change links + a possibly breaking change
- [togeojson changelog](https://github.com/mapbox/togeojson/blob/v0.11.1/CHANGELOG.md)
- [diff `v0.10.1`...`v0.11.1`](https://github.com/mapbox/togeojson/compare/v0.10.1...v0.11.1)
  - [`NaN` elevation behavior](https://github.com/mapbox/togeojson/compare/v0.10.1...v0.11.1#diff-0739b946681e8df98e3b0d3c0e741ab2R57) previously if the elevation tag was present but had no value, then an elevation value of `NaN` could have been pushed to the array. Now it will just not have a third value in the coord array