### PR TITLE
Remove examples IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Live examples:
 * [CSV](https://www.mapbox.com/mapbox.js/example/v1.0.0/markers-from-csv/)
 
 ```js
-var map = L.mapbox.map('map', 'examples.map-9ijuk24y')
+var map = L.mapbox.map('map', 'mapbox.streets')
     .setView([38, -102.0], 5);
 
 omnivore.csv('a.csv').addTo(map);

--- a/test/demo.html
+++ b/test/demo.html
@@ -15,7 +15,7 @@
 <body>
 <div id='map'></div>
 <script>
-var map = L.mapbox.map('map', 'examples.map-9ijuk24y')
+var map = L.mapbox.map('map', 'mapbox.streets')
     .setView([38, -102.0], 5);
 
 function log(_) {


### PR DESCRIPTION
Switches out `examples` map IDs with `mapbox.streets`. @tmcw 