### PR TITLE
Add main entry to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,8 @@
 {
   "name": "leaflet-omnivore",
   "version": "0.3.0",
-  "description": "a geospatial format parser for Leaflet"
+  "description": "a geospatial format parser for Leaflet",
+  "main": [
+    "leaflet-omnivore.js"
+  ]
 }


### PR DESCRIPTION
Allow tools like [grunt wiredep](https://github.com/stephenplusplus/grunt-wiredep) to automatically inject a script tag for this library after installing with bower.