### PR TITLE
Check CSV for empty strings

### DIFF
--- a/leaflet-omnivore.js
+++ b/leaflet-omnivore.js
@@ -534,7 +534,7 @@ function csv2geojson(x, options, callback) {
 
     for (var i = 0; i < parsed.length; i++) {
         if (parsed[i][lonfield] !== undefined &&
-            parsed[i][lonfield] !== undefined) {
+            parsed[i][lonfield] !== "") {
 
             var lonk = parsed[i][lonfield],
                 latk = parsed[i][latfield],


### PR DESCRIPTION
You were previously checking if parsed[i][lonfield] was undefined twice within the same if statement.  I removed the duplicated check, and added a check for empty strings which I think is what was originally intended for the second part of the if statement.