### PR TITLE
Don't crash on strange GPX files

### DIFF
--- a/leaflet-omnivore.js
+++ b/leaflet-omnivore.js
@@ -1016,6 +1016,9 @@ toGeoJSON = (function() {
                 var segments = get(node, 'trkseg'), track = [], times = [], line;
                 for (var i = 0; i < segments.length; i++) {
                     line = getPoints(segments[i], 'trkpt');
+                    if (!line) {
+                        continue;
+                    }
                     if (line.line) track.push(line.line);
                     if (line.times.length) times.push(line.times);
                 }


### PR DESCRIPTION
When there was only one trkpt (exported from QGIS), the import crashed.
Now we ignore that.