### PR TITLE
fixed headless test commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "zuul --local -- test/test.js",
     "test-remote": "zuul -- test/test.js",
-    "test-headless": "zuul --phantom test/test.js",
+    "test-headless": "zuul --phantom -- test/test.js",
     "build": "browserify -s omnivore index.js > leaflet-omnivore.js && uglifyjs leaflet-omnivore.js -c -m > leaflet-omnivore.min.js"
   },
   "repository": {


### PR DESCRIPTION
This is why the travis test failed and reported:

"at least one `js` test file must be specified"