### PR TITLE
Security Threat - Update st from 1.10 to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jshint": "2.9.2",
     "mocha": "~2.5.3",
     "zuul": "~3.10.1",
-    "st": "1.1.0",
+    "st": "1.2.2",
     "mapbox.js": "2.4.0",
     "phantomjs-prebuilt": "2.1.7"
   }


### PR DESCRIPTION
Update st from 1.10 to 1.2.2 to stop known security threat. Threat description: https://nvd.nist.gov/vuln/detail/CVE-2017-16224

I receive weekly emails from GitHub about st's version number having a known security threat.

GitHub's suggestion was to update st to it's latest version, 1.2.2.

Thank you for your time,
Barret

forwarding from 
ISSUE: https://github.com/rstudio/leaflet/issues/585
PR: https://github.com/rstudio/leaflet/pull/575
