### PR TITLE
Fix the KML to GeoJSON conversion not setting up the correct feature styles in Leaflet for LineStrings

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,6 +226,13 @@ function kmlParse(gpx, options, layer) {
     layer = layer || L.geoJson();
     var geojson = toGeoJSON.kml(xml);
     addData(layer, geojson);
+    layer.eachLayer(function (sublayer) {
+        if (sublayer.feature.geometry.type === 'LineString' && sublayer.feature.properties.stroke) {
+            sublayer.feature.properties.color = sublayer.feature.properties.stroke;
+            sublayer.feature.properties.stroke = true;
+            sublayer.setStyle(sublayer.feature.properties);
+        }
+    });
     return layer;
 }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/mapbox/leaflet-omnivore",
   "dependencies": {
     "csv2geojson": "~5.0.0",
-    "togeojson": "0.13.0",
+    "togeojson": "0.16.0",
     "corslite": "0.0.7",
     "wellknown": "0.4.2",
     "brfs": "1.4.3",


### PR DESCRIPTION
The problem is that for `LineString` geometry type the `stroke` property contains a hex color, whereas Leaflet expects it to be a `color` and `stroke` to be a boolean value. Please correct me if I'm wrong.